### PR TITLE
Add ignoreHTTPSErrors option for regression tests

### DIFF
--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -79,6 +79,7 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
         storageState: FXN_DESIGNER_STORAGE_STATE,
+        ignoreHTTPSErrors: true,
       },
       retries: 2,
       workers: 1,


### PR DESCRIPTION
This PR adds the ignoreHTTPSErrors option to regression tests.

This option is already used on e2e tests as well. This is an alignment with that strategy.